### PR TITLE
feat(empty): keep nested empty objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ class HakunaTupu {
         if (obj[key] && typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
           if (Object.keys(obj[key]).length !== 0) {
             const nestedObj = this.removeEmpty(obj[key]);
-            if (Object.keys(nestedObj).length) {
+            if (Object.keys(nestedObj).length || !this.options.removeEmptyObjects) {
               finalObj[key] = nestedObj;
             }
           }

--- a/test/mocks/defaultObject.js
+++ b/test/mocks/defaultObject.js
@@ -10,6 +10,11 @@ module.exports = {
   aaaaaaaaa: false,
   emptyObj: {},
   emptyArray: [],
+  emptyNestedObj: {
+    emptyNestedObj: {
+      a: ''
+    }
+  },
   array: [
     {
       a: '',

--- a/test/mocks/notRemoveEmptyObject.js
+++ b/test/mocks/notRemoveEmptyObject.js
@@ -6,6 +6,9 @@ module.exports = {
   aaaaaaaa: true,
   aaaaaaaaa: false,
   emptyObj: {},
+  emptyNestedObj: {
+    emptyNestedObj: {}
+  },
   array: [
     {
       aaaa: 'aaaa',

--- a/test/mocks/notRemoveEmptyStrings.js
+++ b/test/mocks/notRemoveEmptyStrings.js
@@ -6,6 +6,11 @@ module.exports = {
   aaaaaaa: 2,
   aaaaaaaa: true,
   aaaaaaaaa: false,
+  emptyNestedObj: {
+    emptyNestedObj: {
+      a: ''
+    }
+  },
   array: [
     {
       a: '',


### PR DESCRIPTION
Fix to keep nested empty objects from being removed.

alternatively, we could add a new option removeNestedEmptyObjects but feels too much ;)